### PR TITLE
Add multiple and more explicit target paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/msurdi/frontend-dependencies.svg?branch=master)](https://travis-ci.org/msurdi/frontend-dependencies)
 
-frontend-dependencies
-=====================
+
+# frontend-dependencies
 
 Utility for copying npm installed packages into a different directory.
 
@@ -9,13 +9,12 @@ For example, you might wish to use this for automatically copying `node_modules/
 after running `npm install` in your project.
 
 
-Installation
-------------
+## Installation
 
 `npm install --save frontend-dependencies`
 
-Configuration
--------------
+
+### Configuration
 
 Add to your `package.json` a section like:
 
@@ -23,10 +22,49 @@ Add to your `package.json` a section like:
         "target": "static/build",
         "packages": [
           "jquery",
-          "normalize.css"
+          "normalize.css",
+          {"src":"jquery/dist"},
+          {"src":"normalize", "target":"vendor"},
+          {"src":"jquery/dist/core.js", "target":"js/whatever.js", "exact":true}
         ]
       }
- 
+
+
+
+### Packages Value Types
+
+
+#### String
+
+
+Path to a file or directory that is relative to the node_modules directory.
+
+
+##### Examples
+
+* `["jquery"]`: copies contents of `node_modules/jquery` to `static/build/jquery/`
+* `["normalize.css"]` copies `node_modules/normalize/normalize.css` to `static/build/normalize/normalize.css`
+
+
+#### Object
+
+Object values allow different targets per item. The also allow setting an exact target, bypassing the default behavior that creates a subdirectory based on the source module's name.
+
+* `src` (required): works exactly like the string syntax shown above
+* `target` (optional): define a custom target, works exactly like frontendDependencies.target
+* `exact` (optional): changes the behavior of target to be the exact destination.
+
+
+##### Examples
+
+* `[{"src":"jquery/dist"}]` : copies contents of `node_modules/jquery/dist` to `static/build/jquery/`
+* `[{"src":"normalize", "target":"vendor"}]`: copies contents of `node_modules/normalize` to `vendor/normalize/`
+* `[{"src":"jquery/dist/core.js", "target":"js/whatever.js", "exact":true]`: copies `node_modules/dist/core.js` to `js/whatever.js`
+* `[{"src":"jquery/dist/", "target":"myjquery", "exact":true]`: copies contents of `node_modules/dist/` to `myjquery/`
+
+
+## Execution
+
 The packages listed in `frontendDependencies.packages` should have been already installed with 
 `npm install --save <packagename>` or similar, that means they should exist.
 
@@ -36,10 +74,10 @@ by adding to your package.json scripts sections something like:
     "scripts": {
         "postinstall": "./node_modules/.bin/frontend-dependencies"
     }
-    
+
 You can see a complete example [here](https://github.com/msurdi/frontend-dependencies/blob/master/fixtures/package.json)
-    
-Tests
------
+
+
+## Tests
 
 `npm test`

--- a/index.js
+++ b/index.js
@@ -22,31 +22,59 @@ function frontendDependencies(workDir) {
         fail("No 'frontendDependencies' key in package.json");
     }
 
-    if (!packageJson.frontendDependencies.target) {
-        fail("No 'frontendDependencies.target' key in package.json");
-    }
-
     if (!packageJson.frontendDependencies.packages) {
         fail("No 'frontendDependencies.packages' key in package.json");
     }
 
     var packages = packageJson.frontendDependencies.packages || [];
     for (var i = 0; i < packages.length; i++) {
-        var packageName = packages[i].split("/").slice(0, 1)[0];
-        var desiredFilesGlob = packages[i].split("/").slice(1).join("/") || "/*";
+        // set defaults
+        var targetPath = null;
+        var exact = false;
+        var entry = packages[i];
+
+        // new optional syntax that lets each entry have a different target
+        if (typeof entry === "object") {
+            if(!entry.hasOwnProperty('src')) {
+                fail("Entry missing src key");
+            }
+
+            if(entry.hasOwnProperty('target')) {
+                targetPath = entry.target
+            }
+
+            exact = entry.hasOwnProperty('exact') && entry.exact == true;
+            entry = entry.src;
+        }
+
+        // set a default target if not set via object
+        if (!targetPath) {
+            if(!packageJson.frontendDependencies.target) {
+                fail("No 'frontendDependencies.target' key in package.json");
+            }
+            targetPath = packageJson.frontendDependencies.target;
+        }
+
+
+        var packageName = entry.split("/").slice(0, 1)[0];
+        var desiredFilesGlob = entry.split("/").slice(1).join("/") || "/*";
         var modulePath = path.join(workDir, "node_modules", packageName);
         var desiredFilesPath = path.join(modulePath, desiredFilesGlob);
-        var targetPath = path.join(workDir, packageJson.frontendDependencies.target, packageName);
+        targetPath = path.join(workDir, targetPath);
 
         if (!shell.test("-d", modulePath)) {
             fail("Module not found or not a directory: " + modulePath);
         }
 
-        shell.mkdir("-p", targetPath);
-        shell.cp("-r", desiredFilesPath, targetPath);
+        if (exact) {
+            shell.mkdir("-p", path.dirname(targetPath));
+            shell.cp("-r", desiredFilesPath, targetPath);
+        } else {
+            targetPath = path.join(targetPath, packageName);
+            shell.mkdir("-p", targetPath);
+            shell.cp("-r", desiredFilesPath, targetPath);
+        }
     }
-
-
 }
 
 function fail(reason) {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 "use strict";
 var shell = require("shelljs");
 var path = require("path");
+var fs = require("fs");
 
 module.exports = frontendDependencies;
 
@@ -67,7 +68,18 @@ function frontendDependencies(workDir) {
         }
 
         if (exact) {
-            shell.mkdir("-p", path.dirname(targetPath));
+            var sourceIsFile = false;
+            try {
+                sourceIsFile = fs.lstatSync(desiredFilesPath).isFile()
+            } catch(e) { /* don't care */ }
+
+            if (sourceIsFile) {
+                // if source is a file, create the target parent directory
+                shell.mkdir("-p", path.dirname(targetPath));
+            } else {
+                // if source is a directory, create the full target path
+                shell.mkdir("-p", targetPath)
+            }
             shell.cp("-r", desiredFilesPath, targetPath);
         } else {
             targetPath = path.join(targetPath, packageName);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-dependencies",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Copies node packages to a directory where your frontend tools will be able to find them",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Adds ability to set package values to objects that allow each item to have a different destination.

In addition to that, it allows you to skip the default behavior of placing each package in a subdirectory of the target that matches the source package.