### PR TITLE
Add more help.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,15 @@ Make it a postinstall script by adding this to your package.json:
         "postinstall": "node ./node_modules/frontend-dependencies/index.js"
     }
 ```
+If postinstall did not run you can use `npm run postinstall` command after installed.
 
 Run can also run it by hand
 
 > ./node_modules/.bin/frontend-dependencies
+
+For Windows user, please run it in PowerShell or use this command in Command Prompt.
+
+> node_modules\\.bin\frontend-dependencies.cmd
 
 ### Packages Options
 


### PR DESCRIPTION
Not all users are familiar with command line. So, add a bit more help message can make their life easier.
However `postinstall` in `scripts` did not run with `npm install` command. ( https://stackoverflow.com/questions/31000392/npm-how-to-just-run-post-install ). This need a little more describe to tell user how to make this script work.