### PR TITLE
feat: add support for copying multiple files to multiple targets (#19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 /test/test2/static/build/**
 /test/test2/node_modules
 /test/test2/package-lock.json
+
+/test/test3/static/build/**
+/test/test3/node_modules
+/test/test3/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
 ![Node.js CI](https://github.com/msurdi/frontend-dependencies/workflows/Node.js%20CI/badge.svg)
 
-
 # frontend-dependencies
 
 Easily manage your frontend dependencies in `package.json`:
 Install node modules and copy desired files to each directory.
 You can use all frontendDependencies also in the backend (isomorph JavaScript).
 
-NOTE: There is a breaking change from Version `0.4.0` to `1.0.0`. Be sure to update your projects to the new syntax!
+## Key Features
 
+* **Centralized Management**: Manage all your frontend dependencies directly within your `package.json`.
+* **Selective Extraction**: Specify exactly which files or folders to copy from a package (e.g., only minified JS and CSS files).
+* **Multiple Targets**: Use the `files` array option to distribute different files of a single package to different target directories (e.g., JS to one folder, CSS to another).
+* **Automatic Namespacing**: Prevents file naming conflicts across packages by optionally creating parent directories for copied files.
+* **Flexible Sourcing**: Pull dependencies from npm versions, tags, Git URLs, SSH, tarballs, or local folders.
+* **Production Focus**: Intelligently skips devDependencies during installation to reduce overhead and download times.
+
+NOTE: There is a breaking change from Version `0.4.0` to `1.0.0`. Be sure to update your projects to the new syntax!
 
 ## Example
 
@@ -48,7 +55,6 @@ Your target folder in your project will look like:
    |    |_ jquery.min.js
    |    |_ normalize.css
    |
-
 ```
 
 ## Full example
@@ -72,15 +78,30 @@ Your target folder in your project will look like:
 
       "jquery": {               // with options
           "version": "3.1.0",   // for `npm install`: version, tag or version range
-          "src": "dist/*"       // relative path in package to copy files
+          "src": "dist/*",      // relative path in package to copy files
           "namespaced": true    // extra parent folder with package Name
       },
 
       "turbolinks": {
-          // alternative to 'version`: specifie git url, tarball url, tarball file, folder
+          // alternative to 'version`: specify git url, tarball url, tarball file, folder
           "url": "git://github.com/turbolinks/turbolinks.git",     
           "src": "{src,LICENSE}", // copy multiple files
           "target": "static/turbo" // specific target path
+      },
+
+      "bootstrap": {
+          "version": "5.3.3",
+          // Use 'files' array to copy multiple sources to multiple targets (ignores namespacing)
+          "files": [
+            {
+              "src": "dist/css/*",
+              "target": "static/css/bootstrap"
+            },
+            {
+              "src": "dist/js/*",
+              "target": "static/js/bootstrap"
+            }
+          ]
       }
     }
   }
@@ -93,6 +114,18 @@ Your target folder in your project will look like:
  project
    |
    |_ static
+   |   |
+   |   |_ css
+   |   |    |_ bootstrap
+   |   |         |_ bootstrap.css
+   |   |         |_ bootstrap.min.css
+   |   |         |_ ...
+   |   |
+   |   |_ js
+   |   |    |_ bootstrap
+   |   |         |_ bootstrap.js
+   |   |         |_ bootstrap.min.js
+   |   |         |_ ...
    |   |
    |   |_ jquery
    |   |    |_ core.js
@@ -112,9 +145,8 @@ Your target folder in your project will look like:
    |        |
    |        |_ LICENSE
    |
-   |
-
 ```
+
 
 
 ## Installation
@@ -131,7 +163,7 @@ Make it a postinstall script by adding this to your package.json:
 If postinstall did not run you can use this after installed:
 > npm run postinstall
 
-Run can also run it with
+You can also run it with:
 > ./node_modules/.bin/frontend-dependencies
 
 Windows user run it in PowerShell or use this command in Command Prompt:
@@ -147,6 +179,7 @@ The npm package name is taken from the specified name in "frontendDependencies.p
     "version": "beta"    // tag
     "version": "^0.2.4"  // version range
 ```
+
 #### url
 Alternative sources for your packages.
 ```js
@@ -166,7 +199,7 @@ The source file(s) or folder(s) within each npm package to be copied.
    // option 2: copy one file or folder
    "src": "dist/*"
 
-   // option 3: copy serveral files or folders
+   // option 3: copy several files or folders
    "src": "{index.js,index.css}"
 ```
 
@@ -178,6 +211,21 @@ The source file(s) or folder(s) within each npm package to be copied.
    "target": "dest"
 ```
 
+#### files (Multiple Sources & Targets)
+If you need to distribute different files from the same package into entirely different directories, you can pass an array of `files` config objects containing `src` and `target`. When the `files` array is used, any `namespaced` option on the package is ignored for those entries.
+
+```js
+   "files": [
+      {
+         "src": "dist/css/*",
+         "target": "public/css/vendor"
+      },
+      {
+         "src": "dist/js/*",
+         "target": "public/js/vendor"
+      }
+   ]
+```
 
 #### namespaced copy
 Often you will copy just a single file from a package and copy it in your static files folder. Doing this for 4 files, you won't experience namespace errors. If you copy more files or the whole folder (= no `src` option defined), then you want to create a parent folder with the actual module name. Enable this with the `namespaced` option; the default is false.
@@ -196,7 +244,6 @@ If neither `src` nor `namespaced` options are specified as in the example below,
    "version": "4.2.0"
 }
 // => conflicts prevented, by parent folders with module name
-
 ```
 
 ## Tests

--- a/index.js
+++ b/index.js
@@ -65,25 +65,42 @@ function frontendDependencies(workDir) {
     for (var pkgName in packages) {
 
         var pkg = packages[pkgName];
+        var modulePath = getAndValidateModulePath(workDir, pkgName);
 
-        // process further options
-        var namespaced = pkg.namespaced || false;
+        if (pkg.files && Array.isArray(pkg.files)) {
+            for (var i = 0; i < pkg.files.length; i++) {
+                var fileConfig = pkg.files[i];
+                var sourceFilesPath = path.join(modulePath, fileConfig.src || "/*");
+                
+                var tarPath = fileConfig.target;
+                var targetPath;
+                if (tarPath) {
+                    targetPath = path.join(workDir, tarPath);
+                } else {
+                    targetPath = getAndValidateTargetPath(pkg, packageJson, workDir, pkgName);
+                }
+                
+                // namespaced will be ignored and the files will be downloaded on the given target path
+                copyFiles(sourceFilesPath, targetPath, pkgName, false);
+            }
+        } else {
+            // process further options
+            var namespaced = pkg.namespaced || false;
 
-        // all files of package are copied (src not defined)
-        // => prevent namespace errors by creating a subfolder
-        if (!pkg.hasOwnProperty('namespaced') && !pkg.hasOwnProperty('src')){
-          namespaced = true
+            // all files of package are copied (src not defined)
+            // => prevent namespace errors by creating a subfolder
+            if (!pkg.hasOwnProperty('namespaced') && !pkg.hasOwnProperty('src')){
+              namespaced = true
+            }
+
+            // prepare folder pathes
+            var sourceFilesPath = path.join(modulePath, pkg.src || "/*");
+            //  eg.: /opt/myProject/node_modules/jquery/dist/*
+            //  eg.: /opt/myProject/node_modules/jquery/dist/{file1,file2}
+            var targetPath = getAndValidateTargetPath(pkg, packageJson, workDir, pkgName);
+
+            copyFiles(sourceFilesPath, targetPath, pkgName, namespaced);
         }
-
-        // prepare folder pathes
-        var modulePath = getAndValidateModulePath(workDir, pkgName)
-        var sourceFilesPath = path.join(modulePath, pkg.src || "/*");
-        //  eg.: /opt/myProject/node_modules/jquery/dist/*
-        //  eg.: /opt/myProject/node_modules/jquery/dist/{file1,file2}
-        var targetPath = getAndValidateTargetPath(pkg, packageJson, workDir, pkgName);
-
-
-        copyFiles(sourceFilesPath, targetPath, pkgName, namespaced);
     }
 
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Copies node packages to a directory where your frontend tools will be able to find them",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha ./test/test.js"
+    "test": "mocha ./test/test.js"
   },
   "bin": {
     "frontend-dependencies": "./index.js"
@@ -32,6 +32,10 @@
     {
       "name": "Felix Furtmayr",
       "email": "ff@rapidfacture.com"
+    },
+    {
+      "name": "chauhan739",
+      "email": "chauhan.aryansingh18@gmail.com"
     }
   ],
   "license": "MIT",

--- a/test/test.js
+++ b/test/test.js
@@ -71,3 +71,31 @@ describe("frontend-dependencies testCase 2", function () {
         });
     });
 });
+
+describe("frontend-dependencies testCase 3", function () {
+    describe("when there are node modules", function () {
+        this.timeout(15000);
+        before(function (done) {
+            shell.cd("test3");
+            shell.rm("-rf", ["node_modules", "static/build/*"]); // cleanup
+            frontendDependencies();
+            done();
+        });
+
+        it("should have copied bootstrap css to static/build/bootstrap/css", function () {
+            assert.ok(shell.test("-d", "static/build/bootstrap/css"));
+            assert.ok(shell.test("-f", "static/build/bootstrap/css/bootstrap.css"));
+            assert.ok(shell.test("-f", "static/build/bootstrap/css/bootstrap.min.css"));
+        });
+
+        it("should have copied bootstrap js to static/build/bootstrap/js", function () {
+            assert.ok(shell.test("-d", "static/build/bootstrap/js"));
+            assert.ok(shell.test("-f", "static/build/bootstrap/js/bootstrap.js"));
+            assert.ok(shell.test("-f", "static/build/bootstrap/js/bootstrap.min.js"));
+        });
+
+        after(function () {
+            shell.cd("..");
+        });
+    });
+});

--- a/test/test3/package.json
+++ b/test/test3/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "frontend-dependencies-test3",
+  "version": "1.0.0",
+  "description": "frontend-dependencies test project for multiple files to multiple targets",
+  "main": "index.js",
+  "author": "Matias Surdi <matias@surdi.net>",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "bootstrap": "5.3.3"
+  },
+  "frontendDependencies": {
+    "target": "static/build",
+    "packages": {
+      "bootstrap": {
+        "version": "5.3.3",
+        "files": [
+          {
+            "src": "dist/css/*",
+            "target": "static/build/bootstrap/css"
+          },
+          {
+            "src": "dist/js/*",
+            "target": "static/build/bootstrap/js"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR resolves #19 by introducing the ability to copy multiple files to multiple specific targets from a single dependency package.

Previously, `frontend-dependencies` only allowed specifying a single `src` and `target` per package. With this update, users can define an array of `files` inside a package configuration, providing greater flexibility to organize vendor assets (e.g., splitting a library's CSS and JS into separate target directories).

Changes Made

- **Core Logic** (`index.js`): Updated the module traversal loop to check for the `files` array. If present, it iterates through the rules, resolving paths independently. The old behavior is preserved as a fallback for configurations that don't use the `files` array.

- **Tests** (`test.js`, `test3/`): Added `testCase 3` mirroring the Bootstrap configuration structure. Confirmed that both JS and CSS files correctly transfer to their custom isolated target directories. All 9 assertions across the test suite are passing.